### PR TITLE
Print symbol if error has occurred

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(MODLOADER_VERSION "Preview 1")
+set(MODLOADER_VERSION "Preview 2")
 
 add_subdirectory(dep/funchook)
 

--- a/include/modloader/hook.h
+++ b/include/modloader/hook.h
@@ -9,6 +9,8 @@ extern "C" {
 
 typedef void modloader_hook_t;
 
+void* modloader_dlsym_print_error(const char *sym);
+
 modloader_hook_t* modloader_hook(void *sym, void *hook, void **orig);
 
 void modloader_destroy_hook(modloader_hook_t*);
@@ -48,7 +50,7 @@ public:
     }
 
 
-    AutoHook(const char *sym, void *hook, void **orig) : AutoHook(dlsym(RTLD_DEFAULT, sym), hook, orig) {
+    AutoHook(const char *sym, void *hook, void **orig) : AutoHook(modloader_dlsym_print_error(sym), hook, orig) {
     }
 
     // workaround for a warning

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -9,6 +9,13 @@ using namespace modloader;
 
 extern "C" {
 
+void *modloader_dlsym_print_error(const char *sym) {
+    void *ptr = dlsym(RTLD_DEFAULT, sym);
+    if (!ptr)
+        Log::error("Hook", "Unknown symbol %s", sym);
+    return ptr;
+}
+
 modloader_hook_t *modloader_hook(void *sym, void *hook, void **orig) {
     funchook_t *h = funchook_create();
     if (!h)


### PR DESCRIPTION
```
22:05:37 Error [Hook] Unknown symbol _ZN10BedrockLog7_log_vaEjjPKciS1_P13__va_list_tag
22:05:37 Error [Hook] Error while preparing hook: Disassemble Error: 3
```
much more informative than:
```
21:32:18 Error [Hook] Error while preparing hook: Disassemble Error: 3
```
Also `modloader_dlsym_print_error` can be used by mods developers to prevent unexpected behavior when server update