### PR TITLE
Check all symbol errors immediately

### DIFF
--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -89,7 +89,7 @@ void *ModLoaderImpl::loadLib(std::string const &path) {
         fullPath = path;
     }
 
-    void* ret = dlopen(fullPath.c_str(), RTLD_LAZY);
+    void* ret = dlopen(fullPath.c_str(), RTLD_NOW);
     if (!ret) {
         Log::error("ModLoader", "Failed loading library %s: %s", fullPath.c_str(), dlerror());
         return nullptr;


### PR DESCRIPTION
Since we can't do this at compile time, the next best thing is to make sure all symbols are checked at bootup so that the server doesn't randomly shit itself at runtime due to a rarely used symbol changing.

I don't think there is a good reason to use RTLD_LAZY over RTLD_NOW, particularly considering the size of libraries we're typically dealing with.