### PR TITLE
Add hook macro & std::string api for C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,9 @@ set(MODLOADER_VERSION "Preview 3")
 add_subdirectory(dep/funchook)
 
 add_library(server_modloader SHARED include/modloader/hook.h include/modloader/statichook.h include/modloader/log.h
-        include/modloader/loader.h
-        src/hook.cpp src/log.cpp src/loader.h src/loader.cpp src/elf_helper.cpp src/elf_helper.h src/main.cpp)
+        include/modloader/loader.h include/modloader/cutils.h
+        src/hook.cpp src/log.cpp src/loader.h src/loader.cpp src/elf_helper.cpp src/elf_helper.h src/main.cpp
+        src/cutils.cpp)
 target_link_libraries(server_modloader funchook)
 target_compile_definitions(server_modloader PRIVATE MODLOADER_VERSION="${MODLOADER_VERSION}")
 target_include_directories(server_modloader PUBLIC include/)

--- a/include/modloader/cutils.h
+++ b/include/modloader/cutils.h
@@ -1,0 +1,91 @@
+#ifndef MODLOADER_CUTILS_H
+#define MODLOADER_CUTILS_H
+
+#include <modloader/hook.h>
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#ifndef RTLD_DEFAULT
+#define RTLD_DEFAULT NULL
+#endif
+
+#define SYM(sym)                                            \
+    dlsym(RTLD_DEFAULT, sym)
+
+
+#define SYMCALL(sym, func_proto, ...)                       \
+    ((func_proto)                                           \
+    (SYM(sym)))                                             \
+    (__VA_ARGS__)
+
+
+#define VIRTUAL_CALL(ptr, func_proto, ...)                  \
+    ((func_proto)                                           \
+    ((void *)ptr))                                          \
+    (__VA_ARGS__)
+
+
+#define DEREFERENCE(type, ptr, offset)                      \
+    (*(type*)((uintptr_t)ptr + offset))
+
+
+#define REFERENCE(type, ptr, offset)                        \
+    (type*)((uintptr_t)ptr + offset)
+
+
+// for uintptr_t
+#define PTR_OFFSET(ptr, offset)                             \
+    ((uintptr_t)ptr + offset)
+
+
+#define THOOK(name, ret_type, sym, ...)          		    \
+    typedef ret_type (*_##name##_t)(__VA_ARGS__);           \
+    ret_type _detour_##name(__VA_ARGS__);                   \
+    void _install_##name(void) __attribute__((constructor));\
+    void _destroy_##name(void);                             \
+                                                            \
+    struct _##name {                                        \
+        modloader_hook_t *hook;                             \
+        _##name##_t detour;                                 \
+        _##name##_t original;                               \
+        void (*install)(void);                              \
+        void (*destroy)(void);                              \
+    } name = {NULL, _detour_##name, NULL,                   \
+                _install_##name, _destroy_##name};          \
+                                                            \
+    void _install_##name(void)                              \
+    {                                                       \
+        name.hook = modloader_hook(SYM(sym),                \
+                                name.detour,                \
+                                (void**)&name.original);    \
+    }                                                       \
+                                                            \
+    void _destroy_##name(void)                              \
+    {                                                       \
+        modloader_destroy_hook(name.hook);                  \
+    }                                                       \
+                                                            \
+    ret_type _detour_##name(__VA_ARGS__)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+// void *sstr = std::string::basic_string(const char *c_str)
+void std_string_string(void **sstr, const char *c_str);
+
+// std::string::c_str()
+const char *std_string_c_str(void *sstr);
+
+// std::string::~basic_string()
+void std_string_destroy(void *sstr, bool should_free);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/cutils.cpp
+++ b/src/cutils.cpp
@@ -1,0 +1,20 @@
+#include <modloader/cutils.h>
+#include <string>
+
+void std_string_string(void **sstr, const char *c_str) {
+    if (*sstr != nullptr)
+        new (*sstr) std::string(c_str);
+    else
+        *sstr = new std::string(c_str);
+}
+
+const char *std_string_c_str(void *sstr) {
+	return ((std::string*)sstr)->c_str();
+}
+
+void std_string_destroy(void *sstr, bool should_free) {
+    if (should_free)
+        delete (std::string*)sstr;
+    else
+        ((std::string*)sstr)->~basic_string();
+}


### PR DESCRIPTION
Example:
```c
#include <modloader/cutils.h>
#include <modloader/log.h>

THOOK(on_initialize_logging, void,
		"_ZN15DedicatedServer17initializeLoggingEv",
		uintptr_t this)
{
	on_initialize_logging.original(this);
	
	char array[32];  // sizeof(std::string) == 32
	void *sstr_new = NULL;
	void *sstr_array = array;
	void *sstr_malloc = malloc(32);

	std_string_string(&sstr_new, "Constructed using operator new allocated memory");
	std_string_string(&sstr_array, "Constructed using array allocated memory");
	std_string_string(&sstr_malloc, "Constructed using malloc allocated memory");

	// The block of memory returned by std_string_c_str will be freed after
	// the std::string object is destructed, use strdup to save it if needed!
	char *msg = strdup(std_string_c_str(sstr_new));

	modloader_logd("std::string", std_string_c_str(sstr_new));
	modloader_logd("std::string", std_string_c_str(sstr_array));
	modloader_logd("std::string", std_string_c_str(sstr_malloc));

	std_string_destroy(sstr_new, true);
	std_string_destroy(sstr_array, false);
	std_string_destroy(sstr_malloc, false);
	
	modloader_logw("std::string", msg); // print again
	free((void *)msg);
	free(sstr_malloc);
}
```

Out:
```text
11:45:14 Debug [std::string] Constructed using operator new allocated memory
11:45:14 Debug [std::string] Constructed using array allocated memory
11:45:14 Debug [std::string] Constructed using malloc allocated memory
11:45:14 Warn  [std::string] Constructed using operator new allocated memory
```
